### PR TITLE
feat: support xfiles/xcontent

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,6 @@
 import { basename } from 'path'
 import { BehaviorSubject, Observable, Unsubscribable } from 'rxjs'
+import { TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver-types'
 import { MessageTransports } from '../jsonrpc2/connection'
 import {
     GenericNotificationHandler,
@@ -7,8 +8,8 @@ import {
     NotificationHandler,
     RequestHandler,
 } from '../jsonrpc2/handlers'
-import { Message, MessageType as RPCMessageType } from '../jsonrpc2/messages'
 import { NotificationType, RequestType } from '../jsonrpc2/messages'
+import { Message, MessageType as RPCMessageType } from '../jsonrpc2/messages'
 import { noopTracer, Trace, Tracer } from '../jsonrpc2/trace'
 import {
     InitializedNotification,
@@ -49,6 +50,15 @@ export interface ClientOptions {
 
     /** Called to create the connection to the server. */
     createMessageTransports: () => MessageTransports | Promise<MessageTransports>
+
+    /**
+     * Called when the server requests to list files or get file contents. See
+     * https://github.com/sourcegraph/language-server-protocol/blob/8313aa98092692c17faffda5336b8951fc03266a/extension-files.md
+     */
+    files?: {
+        xfiles: (base?: string) => Promise<TextDocumentIdentifier[]>
+        xcontent: ({ textDocument }: { textDocument: TextDocumentIdentifier }) => Promise<TextDocumentItem>
+    }
 
     /** Trace log level. The tracer must also be set. */
     trace?: Trace

--- a/src/client/features/extension-files.ts
+++ b/src/client/features/extension-files.ts
@@ -1,0 +1,21 @@
+import { ClientCapabilities } from '../../protocol'
+import { XContentRequest, XFilesRequest } from '../../protocol/extension-files'
+import { _RemoteWorkspace } from '../../server/features/workspace'
+import { Client } from '../client'
+import { StaticFeature } from './common'
+
+export class FilesExtensionFeature implements StaticFeature {
+    constructor(private client: Client) {}
+
+    public fillClientCapabilities(capabilities: ClientCapabilities): void {
+        capabilities.files = capabilities.files || false
+    }
+
+    public initialize(): void {
+        if (!this.client.options.files) {
+            return
+        }
+        this.client.onRequest(XFilesRequest.type, (params, token) => this.client.options.files!.xfiles(params))
+        this.client.onRequest(XContentRequest.type, (params, token) => this.client.options.files!.xcontent(params))
+    }
+}

--- a/src/environment/controller.ts
+++ b/src/environment/controller.ts
@@ -12,6 +12,7 @@ import {
     TextDocumentDynamicDecorationFeature,
     TextDocumentStaticDecorationFeature,
 } from '../client/features/decoration'
+import { FilesExtensionFeature } from '../client/features/extension-files'
 import { TextDocumentHoverFeature } from '../client/features/hover'
 import {
     TextDocumentDefinitionFeature,
@@ -248,6 +249,9 @@ export class Controller<X extends Extension = Extension> implements Unsubscribab
                     })
             )
         )
+        if (client.options.files) {
+            client.registerFeature(new FilesExtensionFeature(client))
+        }
     }
 
     public readonly environment: ObservableEnvironment<X> = createObservableEnvironment<X>(this._environment)

--- a/src/protocol/capabilities.ts
+++ b/src/protocol/capabilities.ts
@@ -6,6 +6,7 @@ import { ConfigurationClientCapabilities } from './configuration'
 import { ContributionClientCapabilities, ContributionServerCapabilities } from './contribution'
 import { DecorationClientCapabilities, DecorationServerCapabilities } from './decoration'
 import { DocumentLinkOptions } from './documentLink'
+import { FilesExtensionClientCapabilities } from './extension-files'
 import { ImplementationClientCapabilities, ImplementationServerCapabilities } from './implementation'
 import { SignatureHelpOptions } from './signatureHelp'
 import { TextDocumentClientCapabilities, TextDocumentSyncKind, TextDocumentSyncOptions } from './textDocument'
@@ -41,7 +42,8 @@ export type ClientCapabilities = _ClientCapabilities &
     ConfigurationClientCapabilities &
     ColorClientCapabilities &
     ContributionClientCapabilities &
-    DecorationClientCapabilities
+    DecorationClientCapabilities &
+    FilesExtensionClientCapabilities
 
 /**
  * Defines the capabilities provided by a language

--- a/src/protocol/extension-files.ts
+++ b/src/protocol/extension-files.ts
@@ -1,0 +1,28 @@
+import { TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver-types'
+import { RequestHandler } from '../jsonrpc2/handlers'
+import { RequestType } from '../jsonrpc2/messages'
+import { TextDocumentRegistrationOptions } from './textDocument'
+
+export interface FilesExtensionClientCapabilities {
+    files?: boolean
+}
+
+export interface XContentParams {
+    textDocument: TextDocumentIdentifier
+}
+
+export type XFilesParams = string
+
+export namespace XContentRequest {
+    export const type = new RequestType<XContentParams, TextDocumentItem, void, TextDocumentRegistrationOptions>(
+        'workspace/xcontent'
+    )
+    export type HandlerSignature = RequestHandler<XContentParams, TextDocumentItem, void>
+}
+
+export namespace XFilesRequest {
+    export const type = new RequestType<XFilesParams, TextDocumentIdentifier[], void, TextDocumentRegistrationOptions>(
+        'workspace/xfiles'
+    )
+    export type HandlerSignature = RequestHandler<XFilesParams, TextDocumentIdentifier[], void>
+}


### PR DESCRIPTION
This adds support for the files extension https://github.com/sourcegraph/language-server-protocol/blob/master/extension-files.md

On the client side:

```typescript
export const CXP_CONTROLLER = createCXPController(
    { files: { xfiles: ..., xcontent: ... } }, // callbacks to handle file list and content requests
    CXP_EXTENSIONS_CONTEXT_CONTROLLER.context,
    createMessageTransports
)
```

On the server side:

```typescript
connection.sendRequest(XContentRequest.type, { textDocument: { uri: 'someuri' } }).then(...)
```