### PR TITLE
chore: rename npm package to sourcegraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After writing and publishing an extension (using `src extensions publish` in the
 
 The Sourcegraph extension API (this repository) is the open-source extension API that Sourcegraph extensions are written against. It exposes concepts present in all clients, such as notifications of opened/closed documents, adding buttons to toolbars, changing the background or gutter color of lines, showing hover tooltips, etc.
 
-The (temporarily named) [@sourcegraph/sourcegraph.proposed](https://npmjs.com/package/@sourcegraph/sourcegraph.proposed) npm package (published from this repository) exposes this as a TypeScript/JavaScript API that is familiar to anyone who has written a [VS Code](https://code.visualstudio.com/) extension.
+The [sourcegraph](https://npmjs.com/package/sourcegraph) npm package (published from this repository) exposes this as a TypeScript/JavaScript API that is familiar to anyone who has written a [VS Code](https://code.visualstudio.com/) extension.
 
 #### Adapters to "polyfill" existing tools to run Sourcegraph extensions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@sourcegraph/sourcegraph.proposed",
+	"name": "sourcegraph",
 	"version": "0.0.0-development",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sourcegraph/sourcegraph.proposed",
+  "name": "sourcegraph",
   "version": "0.0.0-development",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",


### PR DESCRIPTION
BREAKING CHANGE: This repository's npm package was renamed from @sourcegraph/sourcegraph.proposed to sourcegraph.