### PR TITLE
Support fetching references by provider name

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -80,10 +80,15 @@ describe('Client', () => {
 
                 // Request registration.
                 client.handleRegistrationRequest({
-                    registrations: [{ id: 'a', method: 'm', registerOptions: { a: 1 }, overwriteExisting: true }],
+                    registrations: [
+                        { id: 'a', method: 'm', registerOptions: { a: 1, extensionID: '' }, overwriteExisting: true },
+                    ],
                 })
                 assert.deepStrictEqual(registerCalls, [
-                    { message: { method: 'm' }, data: { id: 'a', registerOptions: { a: 1 }, overwriteExisting: true } },
+                    {
+                        message: { method: 'm' },
+                        data: { id: 'a', registerOptions: { a: 1, extensionID: '' }, overwriteExisting: true },
+                    },
                 ] as typeof registerCalls)
 
                 // Request unregistration.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -447,6 +447,9 @@ export class Client implements Unsubscribable {
             if (!options.documentSelector && this.options.documentSelector) {
                 options.documentSelector = this.options.documentSelector
             }
+            if (!options.extensionID) {
+                options.extensionID = this.id
+            }
             const data: RegistrationData<any> = {
                 id: registration.id,
                 registerOptions: options,

--- a/src/client/features/common.test.ts
+++ b/src/client/features/common.test.ts
@@ -20,6 +20,9 @@ class TextDocumentFeature extends AbstractTextDocumentFeature<TextDocumentRegist
     protected registerProvider(): Unsubscribable {
         return { unsubscribe: () => void 0 }
     }
+    protected validateRegistrationOptions(data: any): TextDocumentRegistrationOptions {
+        return data
+    }
     public fillClientCapabilities(): void {
         /* noop */
     }
@@ -28,7 +31,7 @@ class TextDocumentFeature extends AbstractTextDocumentFeature<TextDocumentRegist
     }
 }
 
-const FIXTURE_REGISTER_OPTIONS: TextDocumentRegistrationOptions = { documentSelector: ['*'] }
+const FIXTURE_REGISTER_OPTIONS: TextDocumentRegistrationOptions = { documentSelector: ['*'], extensionID: 'test' }
 
 describe('TextDocumentFeature', () => {
     describe('dynamic registration', () => {

--- a/src/client/features/common.ts
+++ b/src/client/features/common.ts
@@ -65,7 +65,20 @@ export abstract class Feature<O> implements DynamicFeature<O> {
 
     public abstract get messages(): RPCMessageType
 
-    public register(message: RPCMessageType, data: RegistrationData<O>): void {
+    /**
+     * validateRegistrationOptions validates a proposed options object. This is used by the register
+     * method to verify registration options. At a minimum, the options
+     * object should conform to O (the options type of a Feature subclass).
+     *
+     * Implementors of this method should return the original options object unmodified if it is
+     * valid and throw an error if it is invalid (i.e., does not satisfy the type).
+     *
+     * @param options the options object to validate
+     */
+    protected abstract validateRegistrationOptions(options: any): O
+
+    public register(message: RPCMessageType, data: RegistrationData<any>): void {
+        const registerOptions = this.validateRegistrationOptions(data.registerOptions)
         if (message.method !== this.messages.method) {
             throw new Error(
                 `Register called on wrong feature. Requested ${message.method} but reached feature ${
@@ -76,7 +89,7 @@ export abstract class Feature<O> implements DynamicFeature<O> {
         if (this.subscriptionsByID.has(data.id)) {
             throw new Error(`registration already exists with ID ${data.id}`)
         }
-        this.subscriptionsByID.set(data.id, this.registerProvider(data.registerOptions))
+        this.subscriptionsByID.set(data.id, this.registerProvider(registerOptions))
     }
 
     protected abstract registerProvider(options: O): Unsubscribable

--- a/src/client/features/decoration.ts
+++ b/src/client/features/decoration.ts
@@ -44,6 +44,13 @@ export class TextDocumentDecorationFeature extends Feature<undefined> {
         )
     }
 
+    protected validateRegistrationOptions(data: any): undefined {
+        if (data) {
+            throw new Error('TextDocumentDecorationFeature registration options should be undefined')
+        }
+        return data
+    }
+
     private getDecorationsSubject(
         textDocument: TextDocumentIdentifier,
         value?: TextDocumentDecoration[] | null

--- a/src/client/features/hover.test.ts
+++ b/src/client/features/hover.test.ts
@@ -10,7 +10,7 @@ const create = (): {
     registry: TextDocumentHoverProviderRegistry
     feature: TextDocumentHoverFeature
 } => {
-    const client = { options: {} } as Client
+    const client = { options: {}, id: 'test' } as Client
     const registry = new TextDocumentHoverProviderRegistry()
     const feature = new TextDocumentHoverFeature(client, registry)
     return { client, registry, feature }
@@ -30,7 +30,10 @@ describe('TextDocumentHoverFeature', () => {
     describe('registration', () => {
         it('supports dynamic registration and unregistration', () => {
             const { registry, feature } = create()
-            feature.register(feature.messages, { id: 'a', registerOptions: { documentSelector: ['*'] } })
+            feature.register(feature.messages, {
+                id: 'a',
+                registerOptions: { documentSelector: ['*'], extensionID: 'test' },
+            })
             assert.strictEqual(registry.providersSnapshot.length, 1)
             feature.unregister('a')
             assert.strictEqual(registry.providersSnapshot.length, 0)

--- a/src/client/features/hover.ts
+++ b/src/client/features/hover.ts
@@ -37,4 +37,12 @@ export class TextDocumentHoverFeature extends Feature<TextDocumentRegistrationOp
                 from(this.client.sendRequest(HoverRequest.type, params))
         )
     }
+
+    protected validateRegistrationOptions(data: any): TextDocumentRegistrationOptions {
+        const options: TextDocumentRegistrationOptions = data
+        if (!options.extensionID) {
+            throw new Error('extensionID should be non-empty in registration options')
+        }
+        return options
+    }
 }

--- a/src/client/features/location.test.ts
+++ b/src/client/features/location.test.ts
@@ -18,7 +18,7 @@ const create = <P extends TextDocumentPositionParams, F extends TextDocumentLoca
     registry: TextDocumentLocationProviderRegistry<P>
     feature: F
 } => {
-    const client = { options: {} } as Client
+    const client = { options: {}, id: 'test' } as Client
     const registry = new RegistryClass()
     const feature = new FeatureClass(client, registry)
     return { client, registry, feature }
@@ -39,7 +39,10 @@ describe('TextDocumentLocationFeature', () => {
                 },
                 TextDocumentLocationProviderRegistry
             )
-            feature.register(feature.messages, { id: 'a', registerOptions: { documentSelector: ['*'] } })
+            feature.register(feature.messages, {
+                id: 'a',
+                registerOptions: { documentSelector: ['*'], extensionID: 'test' },
+            })
             assert.strictEqual(registry.providersSnapshot.length, 1)
             feature.unregister('a')
             assert.strictEqual(registry.providersSnapshot.length, 0)

--- a/src/client/features/location.ts
+++ b/src/client/features/location.ts
@@ -42,6 +42,14 @@ export abstract class TextDocumentLocationFeature<
             (params: P): Observable<L | L[] | null> => from(this.client.sendRequest(this.messages, params))
         )
     }
+
+    protected validateRegistrationOptions(data: any): TextDocumentRegistrationOptions {
+        const options: TextDocumentRegistrationOptions = data
+        if (!options.extensionID) {
+            throw new Error('extensionID should be non-empty in registration options')
+        }
+        return options
+    }
 }
 
 /**

--- a/src/client/features/textDocument.test.ts
+++ b/src/client/features/textDocument.test.ts
@@ -44,7 +44,7 @@ describe('TextDocumentNotificationFeature', () => {
         }
     }
 
-    const FIXTURE_REGISTER_OPTIONS: TextDocumentRegistrationOptions = { documentSelector: ['*'] }
+    const FIXTURE_REGISTER_OPTIONS: TextDocumentRegistrationOptions = { documentSelector: ['*'], extensionID: 'test' }
 
     describe('registration', () => {
         it('supports dynamic registration and unregistration', () => {
@@ -101,7 +101,10 @@ describe('TextDocumentDidOpenFeature', () => {
     describe('when a text document is opened', () => {
         it('sends a textDocument/didOpen notification to the server', done => {
             const { client, environment, feature } = create()
-            feature.register(feature.messages, { id: 'a', registerOptions: { documentSelector: ['l'] } })
+            feature.register(feature.messages, {
+                id: 'a',
+                registerOptions: { documentSelector: ['l'], extensionID: 'id' },
+            })
 
             const textDocument: TextDocumentItem = {
                 uri: 'file:///f',
@@ -161,7 +164,10 @@ describe('TextDocumentDidCloseFeature', () => {
     describe('when a text document is opened and then closed', () => {
         it('sends a textDocument/didClose notification to the server', done => {
             const { client, environment, feature } = create()
-            feature.register(feature.messages, { id: 'a', registerOptions: { documentSelector: ['l'] } })
+            feature.register(feature.messages, {
+                id: 'a',
+                registerOptions: { documentSelector: ['l'], extensionID: 'test' },
+            })
 
             const textDocument: TextDocumentItem = {
                 uri: 'file:///f',

--- a/src/environment/providers/location.ts
+++ b/src/environment/providers/location.ts
@@ -2,6 +2,7 @@ import { combineLatest, from, Observable } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 import { Location } from 'vscode-languageserver-types'
 import { ReferenceParams, TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
+import { compact, flatten } from '../../util'
 import { FeatureProviderRegistry } from './registry'
 import { flattenAndCompact } from './util'
 
@@ -22,6 +23,24 @@ export class TextDocumentLocationProviderRegistry<
     public getLocation(params: P): Observable<L | L[] | null> {
         return getLocation<P, L>(this.providers, params)
     }
+
+    public getLocationsWithExtensionID(params: P): Observable<{ extensionID: string; location: L }[] | null> {
+        return getLocationsWithExtensionID<P, L>(this.providersWithID, params)
+    }
+
+    /**
+     * List of providers with their associated extension ID
+     */
+    public readonly providersWithID: Observable<
+        { extensionID: string; provider: ProvideTextDocumentLocationSignature<P, L> }[]
+    > = this.entries.pipe(
+        map(providers =>
+            providers.map(({ provider, registrationOptions }) => ({
+                extensionID: registrationOptions.extensionID,
+                provider,
+            }))
+        )
+    )
 }
 
 /**
@@ -63,6 +82,29 @@ export function getLocations<
 }
 
 /**
+ * Like getLocations, but includes the ID of the extension that provided each location result
+ */
+export function getLocationsWithExtensionID<
+    P extends TextDocumentPositionParams = TextDocumentPositionParams,
+    L extends Location = Location
+>(
+    providersWithID: Observable<{ extensionID: string; provider: ProvideTextDocumentLocationSignature<P, L> }[]>,
+    params: P
+): Observable<{ extensionID: string; location: L }[]> {
+    return providersWithID.pipe(
+        switchMap(providersWithID =>
+            combineLatest(
+                providersWithID.map(({ provider, extensionID }) =>
+                    provider(params).pipe(
+                        map(r => flattenAndCompactNonNull([r]).map(l => ({ extensionID, location: l })))
+                    )
+                )
+            ).pipe(map(flattenAndCompactNonNull))
+        )
+    )
+}
+
+/**
  * Provides reference results from all extensions.
  *
  * Reference results are always an array or null, unlike results from other location providers (e.g., from
@@ -75,4 +117,9 @@ export class TextDocumentReferencesProviderRegistry extends TextDocumentLocation
         // null).
         return getLocations(this.providers, params)
     }
+}
+
+/** Flattens and compacts the argument. If it is null or if the result is empty, it returns null. */
+function flattenAndCompactNonNull<T>(value: (T | T[] | null)[] | null): T[] {
+    return value ? flatten(compact(value)) : []
 }

--- a/src/environment/providers/registry.ts
+++ b/src/environment/providers/registry.ts
@@ -9,7 +9,7 @@ interface Entry<O, P> {
 
 /** Base class for provider registries for features. */
 export abstract class FeatureProviderRegistry<O, P> {
-    private entries = new BehaviorSubject<Entry<O, P>[]>([])
+    protected entries = new BehaviorSubject<Entry<O, P>[]>([])
 
     public constructor(initialEntries?: Entry<O, P>[]) {
         if (initialEntries) {

--- a/src/protocol/textDocument.ts
+++ b/src/protocol/textDocument.ts
@@ -77,6 +77,11 @@ export interface TextDocumentRegistrationOptions {
      * the document selector provided on the client side will be used.
      */
     documentSelector: DocumentSelector | null
+
+    /**
+     * ID of the extension that registers the provider.
+     */
+    extensionID: string
 }
 
 export interface TextDocumentSyncOptions {


### PR DESCRIPTION
Adds `getLocationsWithProviderName` and `providersWithName` to `TextDocumentLocationProviderRegistry`. The former returns locations with their associated provider's name and the latter returns a list of the providers with their name.

This should be reviewed in conjunction with https://github.com/sourcegraph/sourcegraph/pull/13126