### PR TITLE
fix: provide backcompat for extensions written before the root removal

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -225,6 +225,15 @@ export class Client implements Unsubscribable {
                 connection.onRequest(RegistrationRequest.type, params => this.handleRegistrationRequest(params))
                 connection.onRequest(UnregistrationRequest.type, params => this.handleUnregistrationRequest(params))
 
+                // Initialize static features.
+                for (const feature of this.features) {
+                    if (!DynamicFeature.is(feature)) {
+                        if (feature.initialize) {
+                            feature.initialize()
+                        }
+                    }
+                }
+
                 connection.sendNotification(InitializedNotification.type, {})
 
                 this._state.next(ClientState.Active)

--- a/src/client/features/common.test.ts
+++ b/src/client/features/common.test.ts
@@ -26,9 +26,6 @@ class TextDocumentFeature extends AbstractTextDocumentFeature<TextDocumentRegist
     public fillClientCapabilities(): void {
         /* noop */
     }
-    public initialize(): void {
-        /* noop */
-    }
 }
 
 const FIXTURE_REGISTER_OPTIONS: TextDocumentRegistrationOptions = { documentSelector: ['*'], extensionID: 'test' }

--- a/src/extension/extension.test.ts
+++ b/src/extension/extension.test.ts
@@ -1,6 +1,12 @@
 import * as assert from 'assert'
 import { createConnection as createClientConnection } from '../client/connection'
-import { InitializedNotification, InitializeParams, InitializeRequest, InitializeResult } from '../protocol'
+import {
+    InitializedNotification,
+    InitializeParams,
+    InitializeRequest,
+    InitializeResult,
+    RegistrationRequest,
+} from '../protocol'
 import { createMessageTransports } from '../test/integration/helpers'
 import { activateExtension } from './extension'
 
@@ -15,6 +21,8 @@ describe('activateExtension', () => {
             configurationCascade: { merged: {} },
         }
         const initResult: InitializeResult = {}
+
+        clientConnection.onRequest(RegistrationRequest.type, () => void 0)
 
         const [, result] = await Promise.all([
             activateExtension<{}>(serverTransports, sourcegraph => {


### PR DESCRIPTION
Also sends dynamic capabilities equivalent to the default static capabilities.