### PR TITLE
feat: remove sourcegraphURL from extension API

### DIFF
--- a/src/extension/extensionHost.ts
+++ b/src/extension/extensionHost.ts
@@ -36,9 +36,6 @@ const consoleLogger: Logger = {
 export interface InitData {
     /** The URL to the JavaScript source file (that exports an `activate` function) for the extension. */
     bundleURL: string
-
-    /** @see {@link module:sourcegraph.internal.sourcegraphURL} */
-    sourcegraphURL: string
 }
 
 /**
@@ -140,7 +137,6 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
         internal: {
             sync,
             updateContext: updates => context.updateContext(updates),
-            sourcegraphURL: new URI(initData.sourcegraphURL),
         },
     }
 }

--- a/src/integration-test/helpers.test.ts
+++ b/src/integration-test/helpers.test.ts
@@ -40,10 +40,7 @@ export async function integrationTestContext(): Promise<
     // Ack all configuration updates.
     clientController.configurationUpdates.subscribe(({ resolve }) => resolve(Promise.resolve()))
 
-    const extensionHost = createExtensionHost(
-        { bundleURL: '', sourcegraphURL: 'https://example.com' },
-        serverTransports
-    )
+    const extensionHost = createExtensionHost({ bundleURL: '' }, serverTransports)
 
     // Wait for client to be ready.
     await clientController.clientEntries

--- a/src/sourcegraph.d.ts
+++ b/src/sourcegraph.d.ts
@@ -829,14 +829,6 @@ declare module 'sourcegraph' {
          * @param updates The updates to apply to the context. If a context property's value is null, it is deleted from the context.
          */
         export function updateContext(updates: ContextValues): void
-
-        /**
-         * The URL to the Sourcegraph site that the user's session is associated with. This refers to
-         * Sourcegraph.com (`https://sourcegraph.com`) by default, or a self-hosted instance of Sourcegraph.
-         *
-         * @example `https://sourcegraph.com`
-         */
-        export const sourcegraphURL: URI
     }
 
     /**


### PR DESCRIPTION
It was not used and is not necessary.