### PR TITLE
chore: suppress connection error when disabling an extension

### DIFF
--- a/src/extension/api/configuration.ts
+++ b/src/extension/api/configuration.ts
@@ -36,7 +36,7 @@ class ExtConfigurationSection<C extends object> implements sourcegraph.Configura
  * @template C - The configuration schema.
  */
 export interface ExtConfigurationAPI<C> {
-    $acceptConfigurationData(data: Readonly<C>): void
+    $acceptConfigurationData(data: Readonly<C>): Promise<void>
 }
 
 /**
@@ -48,8 +48,9 @@ export class ExtConfiguration<C extends ConfigurationCascade<any>> implements Ex
 
     constructor(private proxy: ClientConfigurationAPI) {}
 
-    public $acceptConfigurationData(data: Readonly<C>): void {
+    public $acceptConfigurationData(data: Readonly<C>): Promise<void> {
         this.data.next(Object.freeze(data))
+        return Promise.resolve()
     }
 
     public get(): sourcegraph.Configuration<C> {

--- a/src/protocol/jsonrpc2/connection.ts
+++ b/src/protocol/jsonrpc2/connection.ts
@@ -48,7 +48,7 @@ const NullLogger: Logger = Object.freeze({
     },
 })
 
-enum ConnectionErrors {
+export enum ConnectionErrors {
     /**
      * The connection is closed.
      */
@@ -63,7 +63,7 @@ enum ConnectionErrors {
     AlreadyListening = 3,
 }
 
-class ConnectionError extends Error {
+export class ConnectionError extends Error {
     public readonly code: ConnectionErrors
 
     constructor(code: ConnectionErrors, message: string) {
@@ -632,9 +632,15 @@ function _createConnection(transports: MessageTransports, logger: Logger, strate
             }
             state = ConnectionState.Unsubscribed
             unsubscribeEmitter.fire(undefined)
-            const error = new Error('Connection got unsubscribed.')
             for (const key of Object.keys(responsePromises)) {
-                responsePromises[key].reject(error)
+                responsePromises[key].reject(
+                    new ConnectionError(
+                        ConnectionErrors.Unsubscribed,
+                        `The underlying JSON-RPC connection got unsubscribed while responding to this ${
+                            responsePromises[key].method
+                        } request.`
+                    )
+                )
             }
             responsePromises = Object.create(null)
             requestTokens = Object.create(null)


### PR DESCRIPTION
Previously, an unhandled promise rejection could occur when disabling a Sourcegraph extension. Here's a rough sequence of events that could trigger it:

- The user disables an extension in the UI
- The configuration gets updated with `"foo-extension": false`
- sourcegraph-extension-api sends a request over JSON-RPC (which would eventually notify `foo-extension` of this configuration change)
- Before the response comes back, e-c-c removes `foo-extension` from the list of active extensions and sourcegraph-extension-api unsubscribes the connection
- The in-flight responses are rejected
- The rejected promise turns into the console error we see

See https://github.com/sourcegraph/sourcegraph/issues/373