### PR TITLE
refactor: simplify error messages from jsonrpc2 handlers

### DIFF
--- a/src/protocol/jsonrpc2/connection.test.ts
+++ b/src/protocol/jsonrpc2/connection.test.ts
@@ -59,6 +59,46 @@ describe('Connection', () => {
         )
     })
 
+    it('handler throws an Error', () => {
+        const method = 'test/handleSingleRequest'
+        const [serverTransports, clientTransports] = createMessageTransports()
+
+        const server = createConnection(serverTransports)
+        server.onRequest(method, () => {
+            throw new Error('test')
+        })
+        server.listen()
+
+        const client = createConnection(clientTransports)
+        client.listen()
+        return client.sendRequest(method, 'foo').then(
+            _result => assert.fail('want error'),
+            (error: ResponseError<any>) => {
+                assert.strictEqual(error.code, ErrorCodes.InternalError)
+                assert.strictEqual(error.message, 'test')
+            }
+        )
+    })
+
+    it('handler returns a rejected Promise with an Error', () => {
+        const method = 'test/handleSingleRequest'
+        const [serverTransports, clientTransports] = createMessageTransports()
+
+        const server = createConnection(serverTransports)
+        server.onRequest(method, () => Promise.reject(new Error('test')))
+        server.listen()
+
+        const client = createConnection(clientTransports)
+        client.listen()
+        return client.sendRequest(method, 'foo').then(
+            _result => assert.fail('want error'),
+            (error: ResponseError<any>) => {
+                assert.strictEqual(error.code, ErrorCodes.InternalError)
+                assert.strictEqual(error.message, 'test')
+            }
+        )
+    })
+
     it('receives undefined request param as null', () => {
         const method = 'test/handleSingleRequest'
         const [serverTransports, clientTransports] = createMessageTransports()

--- a/src/protocol/jsonrpc2/connection.ts
+++ b/src/protocol/jsonrpc2/connection.ts
@@ -365,12 +365,7 @@ function _createConnection(transports: MessageTransports, logger: Logger, strate
                             if (error instanceof ResponseError) {
                                 replyError(error as ResponseError<any>)
                             } else if (error && typeof error.message === 'string') {
-                                replyError(
-                                    new ResponseError<void>(
-                                        ErrorCodes.InternalError,
-                                        `Request ${requestMessage.method} failed with message: ${error.message}`
-                                    )
-                                )
+                                replyError(new ResponseError<void>(ErrorCodes.InternalError, error.message))
                             } else {
                                 replyError(
                                     new ResponseError<void>(
@@ -392,12 +387,7 @@ function _createConnection(transports: MessageTransports, logger: Logger, strate
                 if (error instanceof ResponseError) {
                     reply(error as ResponseError<any>)
                 } else if (error && typeof error.message === 'string') {
-                    replyError(
-                        new ResponseError<void>(
-                            ErrorCodes.InternalError,
-                            `Request ${requestMessage.method} failed with message: ${error.message}`
-                        )
-                    )
+                    replyError(new ResponseError<void>(ErrorCodes.InternalError, error.message))
                 } else {
                     replyError(
                         new ResponseError<void>(


### PR DESCRIPTION
This makes error messages such as the ones seen in https://github.com/sourcegraph/sourcegraph/issues/366 less cryptic.