### PR TITLE
feat: createPanelView API for extension panels with custom Markdown

### DIFF
--- a/src/client/api/views.ts
+++ b/src/client/api/views.ts
@@ -1,0 +1,72 @@
+import { combineLatest, ReplaySubject, Subject, Subscription } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { handleRequests } from '../../common/proxy'
+import { ContributableViewContainer } from '../../protocol'
+import { Connection } from '../../protocol/jsonrpc2/connection'
+import * as plain from '../../protocol/plainTypes'
+import { ViewProviderRegistry } from '../providers/view'
+import { SubscriptionMap } from './common'
+
+/** @internal */
+export interface ClientViewsAPI {
+    $unregister(id: number): void
+    $registerPanelViewProvider(id: number, provider: { id: string }): void
+    $acceptPanelViewUpdate(id: number, params: Partial<plain.PanelView>): void
+}
+
+interface PanelViewSubjects {
+    title: Subject<string>
+    content: Subject<string>
+}
+
+/** @internal */
+export class ClientViews implements ClientViewsAPI {
+    private subscriptions = new Subscription()
+    private panelViews = new Map<number, Record<keyof plain.PanelView, Subject<string>>>()
+    private registrations = new SubscriptionMap()
+
+    constructor(connection: Connection, private viewRegistry: ViewProviderRegistry) {
+        this.subscriptions.add(this.registrations)
+
+        handleRequests(connection, 'views', this)
+    }
+
+    public $unregister(id: number): void {
+        this.registrations.remove(id)
+    }
+
+    public $registerPanelViewProvider(id: number, provider: { id: string }): void {
+        const panelView: PanelViewSubjects = {
+            title: new ReplaySubject<string>(1),
+            content: new ReplaySubject<string>(1),
+        }
+        this.panelViews.set(id, panelView)
+        const registryUnsubscribable = this.viewRegistry.registerProvider(
+            { ...provider, container: ContributableViewContainer.Panel },
+            combineLatest(panelView.title, panelView.content).pipe(map(([title, content]) => ({ title, content })))
+        )
+        this.registrations.add(id, {
+            unsubscribe: () => {
+                registryUnsubscribable.unsubscribe()
+                this.panelViews.delete(id)
+            },
+        })
+    }
+
+    public $acceptPanelViewUpdate(id: number, params: { title?: string; content?: string }): void {
+        const panelView = this.panelViews.get(id)
+        if (panelView === undefined) {
+            throw new Error(`no panel view with ID ${id}`)
+        }
+        if (params.title !== undefined) {
+            panelView.title.next(params.title)
+        }
+        if (params.content !== undefined) {
+            panelView.content.next(params.content)
+        }
+    }
+
+    public unsubscribe(): void {
+        this.subscriptions.unsubscribe()
+    }
+}

--- a/src/client/controller.ts
+++ b/src/client/controller.ts
@@ -20,6 +20,7 @@ import { ClientContext } from './api/context'
 import { ClientDocuments } from './api/documents'
 import { ClientLanguageFeatures } from './api/languageFeatures'
 import { Search } from './api/search'
+import { ClientViews } from './api/views'
 import { ClientWindows } from './api/windows'
 import { applyContextUpdate, EMPTY_CONTEXT } from './context/context'
 import { EMPTY_ENVIRONMENT, Environment } from './environment'
@@ -249,6 +250,7 @@ export class Controller<X extends Extension, C extends ConfigurationCascade> imp
                     })
             )
         )
+        subscription.add(new ClientViews(client, this.registries.views))
         subscription.add(new ClientCodeEditor(client, this.registries.textDocumentDecoration))
         subscription.add(
             new ClientDocuments(

--- a/src/client/providers/registry.ts
+++ b/src/client/providers/registry.ts
@@ -2,7 +2,7 @@ import { BehaviorSubject, Observable, Unsubscribable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 /** A registry entry for a registered provider. */
-interface Entry<O, P> {
+export interface Entry<O, P> {
     registrationOptions: O
     provider: P
 }

--- a/src/client/providers/view.test.ts
+++ b/src/client/providers/view.test.ts
@@ -1,0 +1,139 @@
+import * as assert from 'assert'
+import { Observable, of, throwError } from 'rxjs'
+import { TestScheduler } from 'rxjs/testing'
+import { ContributableViewContainer } from '../../protocol'
+import * as plain from '../../protocol/plainTypes'
+import { Entry } from './registry'
+import { getView, getViews, ViewProviderRegistrationOptions } from './view'
+
+const FIXTURE_CONTAINER = ContributableViewContainer.Panel
+
+const FIXTURE_ENTRY_1: Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>> = {
+    registrationOptions: { container: FIXTURE_CONTAINER, id: '1' },
+    provider: of<plain.PanelView>({ title: 't1', content: 'c1' }),
+}
+const FIXTURE_RESULT_1 = { container: FIXTURE_CONTAINER, id: '1', title: 't1', content: 'c1' }
+
+const FIXTURE_ENTRY_2: Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>> = {
+    registrationOptions: { container: FIXTURE_CONTAINER, id: '2' },
+    provider: of<plain.PanelView>({ title: 't2', content: 'c2' }),
+}
+const FIXTURE_RESULT_2 = { container: FIXTURE_CONTAINER, id: '2', title: 't2', content: 'c2' }
+
+const scheduler = () => new TestScheduler((a, b) => assert.deepStrictEqual(a, b))
+
+describe('getView', () => {
+    describe('0 providers', () => {
+        it('returns null', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    getView(
+                        cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-|', { a: [] }),
+                        '1'
+                    )
+                ).toBe('-a-|', {
+                    a: null,
+                })
+            ))
+    })
+
+    it('returns result from provider', () =>
+        scheduler().run(({ cold, expectObservable }) =>
+            expectObservable(
+                getView(
+                    cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-|', {
+                        a: [FIXTURE_ENTRY_1],
+                    }),
+                    '1'
+                )
+            ).toBe('-a-|', {
+                a: FIXTURE_RESULT_1,
+            })
+        ))
+
+    describe('multiple emissions', () => {
+        it('returns stream of results', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    getView(
+                        cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-b-|', {
+                            a: [FIXTURE_ENTRY_1],
+                            b: [FIXTURE_ENTRY_1, FIXTURE_ENTRY_2],
+                        }),
+                        '2'
+                    )
+                ).toBe('-a-b-|', {
+                    a: null,
+                    b: FIXTURE_RESULT_2,
+                })
+            ))
+    })
+})
+
+describe('getViews', () => {
+    describe('0 providers', () => {
+        it('returns null', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    getViews(
+                        cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-|', { a: [] }),
+                        FIXTURE_CONTAINER
+                    )
+                ).toBe('-a-|', {
+                    a: null,
+                })
+            ))
+    })
+
+    it('returns result from provider', () =>
+        scheduler().run(({ cold, expectObservable }) =>
+            expectObservable(
+                getViews(
+                    cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-|', {
+                        a: [FIXTURE_ENTRY_1],
+                    }),
+                    FIXTURE_CONTAINER
+                )
+            ).toBe('-a-|', {
+                a: [FIXTURE_RESULT_1],
+            })
+        ))
+
+    it('continues if provider has error', () =>
+        scheduler().run(({ cold, expectObservable }) =>
+            expectObservable(
+                getViews(
+                    cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-|', {
+                        a: [
+                            {
+                                registrationOptions: { container: FIXTURE_CONTAINER, id: 'err' },
+                                provider: throwError('err'),
+                            },
+                            FIXTURE_ENTRY_1,
+                        ],
+                    }),
+                    FIXTURE_CONTAINER
+                )
+            ).toBe('-a-|', {
+                a: [FIXTURE_RESULT_1],
+            })
+        ))
+
+    describe('multiple emissions', () => {
+        it('returns stream of results', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    getViews(
+                        cold<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>('-a-b-|', {
+                            a: [FIXTURE_ENTRY_1],
+                            b: [FIXTURE_ENTRY_1, FIXTURE_ENTRY_2],
+                        }),
+                        FIXTURE_CONTAINER
+                    )
+                ).toBe('-a-b-|', {
+                    a: [FIXTURE_RESULT_1],
+                    b: [FIXTURE_RESULT_1, FIXTURE_RESULT_2],
+                })
+            ))
+    })
+})

--- a/src/client/providers/view.ts
+++ b/src/client/providers/view.ts
@@ -1,0 +1,95 @@
+import { combineLatest, Observable } from 'rxjs'
+import { catchError, map, switchMap } from 'rxjs/operators'
+import { ContributableViewContainer } from '../../protocol'
+import * as plain from '../../protocol/plainTypes'
+import { Entry, FeatureProviderRegistry } from './registry'
+
+export interface ViewProviderRegistrationOptions {
+    id: string
+    container: ContributableViewContainer
+}
+
+export type ProvideViewSignature = Observable<plain.PanelView>
+
+/** Provides views from all extensions. */
+export class ViewProviderRegistry extends FeatureProviderRegistry<
+    ViewProviderRegistrationOptions,
+    ProvideViewSignature
+> {
+    /**
+     * Returns an observable that emits the specified view whenever it or the set of registered view providers
+     * changes. If the provider emits an error, the returned observable also emits an error (and completes).
+     */
+    public getView(id: string): Observable<plain.PanelView | null> {
+        return getView(this.entries, id)
+    }
+
+    /**
+     * Returns an observable that emits all views whenever the set of registered view providers or their properties
+     * change. If any provider emits an error, the error is logged and the provider is omitted from the emission of
+     * the observable (the observable does not emit the error).
+     */
+    public getViews(
+        container: ContributableViewContainer
+    ): Observable<(plain.PanelView & ViewProviderRegistrationOptions)[] | null> {
+        return getViews(this.entries, container)
+    }
+}
+
+/**
+ * Exported for testing only. Most callers should use {@link ViewProviderRegistry#getView}, which uses the
+ * registered view providers.
+ *
+ * @internal
+ */
+export function getView(
+    entries: Observable<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>,
+    id: string
+): Observable<(plain.PanelView & ViewProviderRegistrationOptions) | null> {
+    return entries.pipe(
+        map(entries => entries.find(entry => entry.registrationOptions.id === id)),
+        switchMap(entry => (entry ? addRegistrationOptions(entry) : [null]))
+    )
+}
+
+/**
+ * Exported for testing only. Most callers should use {@link ViewProviderRegistry#getViews}, which uses the
+ * registered view providers.
+ *
+ * @internal
+ */
+export function getViews(
+    entries: Observable<Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>[]>,
+    container: ContributableViewContainer
+): Observable<(plain.PanelView & ViewProviderRegistrationOptions)[] | null> {
+    return entries.pipe(
+        switchMap(
+            entries =>
+                entries && entries.length > 0
+                    ? combineLatest(
+                          entries.filter(e => e.registrationOptions.container === container).map(entry =>
+                              addRegistrationOptions(entry).pipe(
+                                  catchError(err => {
+                                      console.error(err)
+                                      return [null]
+                                  })
+                              )
+                          )
+                      ).pipe(
+                          map(entries =>
+                              entries.filter(
+                                  (result): result is plain.PanelView & ViewProviderRegistrationOptions =>
+                                      result !== null
+                              )
+                          )
+                      )
+                    : [null]
+        )
+    )
+}
+
+function addRegistrationOptions(
+    entry: Entry<ViewProviderRegistrationOptions, Observable<plain.PanelView>>
+): Observable<plain.PanelView & ViewProviderRegistrationOptions> {
+    return entry.provider.pipe(map(view => ({ ...view, ...entry.registrationOptions })))
+}

--- a/src/client/registries.ts
+++ b/src/client/registries.ts
@@ -8,6 +8,7 @@ import { TextDocumentDecorationProviderRegistry } from './providers/decoration'
 import { TextDocumentHoverProviderRegistry } from './providers/hover'
 import { TextDocumentLocationProviderRegistry, TextDocumentReferencesProviderRegistry } from './providers/location'
 import { QueryTransformerRegistry } from './providers/queryTransformer'
+import { ViewProviderRegistry } from './providers/view'
 
 /**
  * Registries is a container for all provider registries.
@@ -27,4 +28,5 @@ export class Registries<X extends Extension, C extends ConfigurationCascade> {
     public readonly textDocumentHover = new TextDocumentHoverProviderRegistry()
     public readonly textDocumentDecoration = new TextDocumentDecorationProviderRegistry()
     public readonly queryTransformer = new QueryTransformerRegistry()
+    public readonly views = new ViewProviderRegistry()
 }

--- a/src/extension/api/common.ts
+++ b/src/extension/api/common.ts
@@ -38,7 +38,7 @@ export class ProviderMap<B> {
      */
     public get<P extends B>(id: number): P {
         const provider = this.map.get(id) as P
-        if (!provider) {
+        if (provider === undefined) {
             throw new Error(`no provider with ID ${id}`)
         }
         return provider

--- a/src/extension/api/views.ts
+++ b/src/extension/api/views.ts
@@ -1,0 +1,50 @@
+import { Unsubscribable } from 'rxjs'
+import * as sourcegraph from 'sourcegraph'
+import { ClientViewsAPI } from '../../client/api/views'
+import { ProviderMap } from './common'
+
+/**
+ * @internal
+ */
+class ExtPanelView implements sourcegraph.PanelView {
+    private _title = ''
+    private _content = ''
+
+    constructor(private proxy: ClientViewsAPI, private id: number, private subscription: Unsubscribable) {}
+
+    public get title(): string {
+        return this._title
+    }
+    public set title(value: string) {
+        this._title = value
+        this.proxy.$acceptPanelViewUpdate(this.id, { title: value })
+    }
+
+    public get content(): string {
+        return this._content
+    }
+    public set content(value: string) {
+        this._content = value
+        this.proxy.$acceptPanelViewUpdate(this.id, { content: value })
+    }
+
+    public unsubscribe(): void {
+        return this.subscription.unsubscribe()
+    }
+}
+
+/** @internal */
+export interface ExtViewsAPI {}
+
+/** @internal */
+export class ExtViews implements ExtViewsAPI {
+    private registrations = new ProviderMap<{}>(id => this.proxy.$unregister(id))
+
+    constructor(private proxy: ClientViewsAPI) {}
+
+    public createPanelView(id: string): ExtPanelView {
+        const { id: regID, subscription } = this.registrations.add({})
+        this.proxy.$registerPanelViewProvider(regID, { id })
+        return new ExtPanelView(this.proxy, regID, subscription)
+    }
+}

--- a/src/extension/extensionHost.ts
+++ b/src/extension/extensionHost.ts
@@ -9,6 +9,7 @@ import { ExtContext } from './api/context'
 import { ExtDocuments } from './api/documents'
 import { ExtLanguageFeatures } from './api/languageFeatures'
 import { ExtSearch } from './api/search'
+import { ExtViews } from './api/views'
 import { ExtWindows } from './api/windows'
 import { Location } from './types/location'
 import { Position } from './types/position'
@@ -77,6 +78,9 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
     const windows = new ExtWindows(proxy('windows'), proxy('codeEditor'), documents)
     handleRequests(connection, 'windows', windows)
 
+    const views = new ExtViews(proxy('views'))
+    handleRequests(connection, 'views', views)
+
     const configuration = new ExtConfiguration<any>(proxy('configuration'))
     handleRequests(connection, 'configuration', configuration)
 
@@ -107,6 +111,7 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
             get windows(): sourcegraph.Window[] {
                 return windows.getAll()
             },
+            createPanelView: id => views.createPanelView(id),
         },
 
         workspace: {

--- a/src/protocol/contribution.ts
+++ b/src/protocol/contribution.ts
@@ -216,3 +216,14 @@ export interface MenuItemContribution {
      */
     group?: string
 }
+
+/** The containers to which an extension can contribute views. */
+export enum ContributableViewContainer {
+    /**
+     * A view that is displayed in the panel for a window.
+     *
+     * Clients: The client should render this as a resizable panel in a window, with multiple tabs to switch
+     * between different panel views.
+     */
+    Panel = 'window/panel',
+}

--- a/src/protocol/plainTypes.ts
+++ b/src/protocol/plainTypes.ts
@@ -33,3 +33,6 @@ export interface TextDocumentDecoration
     extends Pick<sourcegraph.TextDocumentDecoration, Exclude<keyof sourcegraph.TextDocumentDecoration, 'range'>> {
     range: Range
 }
+
+/** The plain properties of a {@link module:sourcegraph.PanelView}, without methods. */
+export interface PanelView extends Pick<sourcegraph.PanelView, 'title' | 'content'> {}

--- a/src/sourcegraph.d.ts
+++ b/src/sourcegraph.d.ts
@@ -6,6 +6,10 @@
 declare module 'sourcegraph' {
     // tslint:disable member-access
 
+    export interface Unsubscribable {
+        unsubscribe(): void
+    }
+
     export class URI {
         static parse(value: string): URI
         static file(path: string): URI
@@ -480,6 +484,21 @@ declare module 'sourcegraph' {
     }
 
     /**
+     * A panel view created by {@link app.registerPanelView}.
+     */
+    export interface PanelView extends Unsubscribable {
+        /**
+         * The title of the panel view.
+         */
+        title: string
+
+        /**
+         * The content to show in the panel view. Markdown is supported.
+         */
+        content: string
+    }
+
+    /**
      * The client application that is running the extension.
      */
     export namespace app {
@@ -495,6 +514,18 @@ declare module 'sourcegraph' {
          * @readonly
          */
         export const windows: Window[]
+
+        /**
+         * Create a panel view for the view contribution with the given {@link id}.
+         *
+         * @todo Consider requiring extensions to specify these statically in package.json's contributions section
+         * to improve the activation experience.
+         *
+         * @param id The ID of the view. This may be shown to the user (e.g., in the URL fragment when the panel is
+         * active).
+         * @returns The panel view.
+         */
+        export function createPanelView(id: string): PanelView
     }
 
     /**
@@ -885,9 +916,5 @@ declare module 'sourcegraph' {
          *          the subscription to stop calling {@link next} with values.
          */
         subscribe(next: (value: T) => void): Unsubscribable
-    }
-
-    export interface Unsubscribable {
-        unsubscribe(): void
     }
 }


### PR DESCRIPTION
Extensions can use the new `sourcegraph.app.createPanelView` API to add panels to the UI. These panels can contain Markdown.

See https://github.com/sqs/sourcegraph-word-count for a sample extension using this API.

Related PR: https://github.com/sourcegraph/extensions-client-common/pull/64