### PR TITLE
feat: supply sourcegraphURL and clientApplication to extensions

### DIFF
--- a/src/extension/extensionHost.ts
+++ b/src/extension/extensionHost.ts
@@ -38,6 +38,12 @@ const consoleLogger: Logger = {
 export interface InitData {
     /** The URL to the JavaScript source file (that exports an `activate` function) for the extension. */
     bundleURL: string
+
+    /** @see {@link module:sourcegraph.internal.sourcegraphURL} */
+    sourcegraphURL: string
+
+    /** @see {@link module:sourcegraph.internal.clientApplication} */
+    clientApplication: 'sourcegraph' | 'other'
 }
 
 /**
@@ -150,6 +156,8 @@ function createExtensionHandle(initData: InitData, connection: Connection): type
         internal: {
             sync,
             updateContext: updates => context.updateContext(updates),
+            sourcegraphURL: new URI(initData.sourcegraphURL),
+            clientApplication: initData.clientApplication,
         },
     }
 }

--- a/src/integration-test/helpers.test.ts
+++ b/src/integration-test/helpers.test.ts
@@ -44,7 +44,10 @@ export async function integrationTestContext(): Promise<
     // Ack all configuration updates.
     clientController.configurationUpdates.subscribe(({ resolve }) => resolve(Promise.resolve()))
 
-    const extensionHost = createExtensionHost({ bundleURL: '' }, serverTransports)
+    const extensionHost = createExtensionHost(
+        { bundleURL: '', sourcegraphURL: 'https://example.com', clientApplication: 'sourcegraph' },
+        serverTransports
+    )
 
     // Wait for client to be ready.
     await clientController.clientEntries

--- a/src/sourcegraph.d.ts
+++ b/src/sourcegraph.d.ts
@@ -904,9 +904,9 @@ declare module 'sourcegraph' {
     }
 
     /**
-     * Internal API for Sourcegraph extensions. These will be removed for the beta release of
-     * Sourcegraph extensions. They are necessary now due to limitations in the extension API and
-     * its implementation that will be addressed in the beta release.
+     * Internal API for Sourcegraph extensions. Most of these will be removed for the beta release of Sourcegraph
+     * extensions. They are necessary now due to limitations in the extension API and its implementation that will
+     * be addressed in the beta release.
      *
      * @internal
      */
@@ -925,6 +925,24 @@ declare module 'sourcegraph' {
          * @param updates The updates to apply to the context. If a context property's value is null, it is deleted from the context.
          */
         export function updateContext(updates: ContextValues): void
+
+        /**
+         * The URL to the Sourcegraph site that the user's session is associated with. This refers to
+         * Sourcegraph.com (`https://sourcegraph.com`) by default, or a self-hosted instance of Sourcegraph.
+         *
+         * @todo Consider removing this when https://github.com/sourcegraph/sourcegraph/issues/566 is fixed.
+         *
+         * @example `https://sourcegraph.com`
+         */
+        export const sourcegraphURL: URI
+
+        /**
+         * The client application that is running this extension, either 'sourcegraph' for Sourcegraph or 'other'
+         * for all other applications (such as GitHub, GitLab, etc.).
+         *
+         * @todo Consider removing this when https://github.com/sourcegraph/sourcegraph/issues/566 is fixed.
+         */
+        export const clientApplication: 'sourcegraph' | 'other'
     }
 
     /**


### PR DESCRIPTION
In some cases, such as to work around https://github.com/sourcegraph/sourcegraph/issues/566, it is useful for extensions to know the Sourcegraph URL and what kind of client application is running it.