### PR TITLE
fix: error emitted from a hover provider broke other hover providers

### DIFF
--- a/src/client/providers/hover.test.ts
+++ b/src/client/providers/hover.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { Hover, MarkupKind } from 'sourcegraph'
 import { HoverMerged } from '../../client/types/hover'
@@ -75,6 +75,20 @@ describe('getHover', () => {
                     getHover(
                         cold<ProvideTextDocumentHoverSignature[]>('-a-|', {
                             a: [() => of(FIXTURE_RESULT), () => of(null)],
+                        }),
+                        FIXTURE.TextDocumentPositionParams
+                    )
+                ).toBe('-a-|', {
+                    a: FIXTURE_RESULT_MERGED,
+                })
+            ))
+
+        it('omits error result from 1 provider', () =>
+            scheduler().run(({ cold, expectObservable }) =>
+                expectObservable(
+                    getHover(
+                        cold<ProvideTextDocumentHoverSignature[]>('-a-|', {
+                            a: [() => throwError('err'), () => of(FIXTURE_RESULT)],
                         }),
                         FIXTURE.TextDocumentPositionParams
                     )

--- a/src/client/providers/hover.ts
+++ b/src/client/providers/hover.ts
@@ -1,5 +1,5 @@
 import { combineLatest, from, Observable } from 'rxjs'
-import { map, switchMap } from 'rxjs/operators'
+import { map, switchMap, catchError } from 'rxjs/operators'
 import { HoverMerged } from '../../client/types/hover'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { Hover } from '../../protocol/plainTypes'
@@ -14,6 +14,11 @@ export class TextDocumentHoverProviderRegistry extends FeatureProviderRegistry<
     TextDocumentRegistrationOptions,
     ProvideTextDocumentHoverSignature
 > {
+    /**
+     * Returns an observable that emits all providers' hovers whenever any of the last-emitted set of providers emits
+     * hovers. If any provider emits an error, the error is logged and the provider is omitted from the emission of
+     * the observable (the observable does not emit the error).
+     */
     public getHover(params: TextDocumentPositionParams): Observable<HoverMerged | null> {
         return getHover(this.providers, params)
     }
@@ -21,7 +26,8 @@ export class TextDocumentHoverProviderRegistry extends FeatureProviderRegistry<
 
 /**
  * Returns an observable that emits all providers' hovers whenever any of the last-emitted set of providers emits
- * hovers.
+ * hovers. If any provider emits an error, the error is logged and the provider is omitted from the emission of
+ * the observable (the observable does not emit the error).
  *
  * Most callers should use TextDocumentHoverProviderRegistry's getHover method, which uses the registered hover
  * providers.
@@ -36,7 +42,18 @@ export function getHover(
                 if (providers.length === 0) {
                     return [[null]]
                 }
-                return combineLatest(providers.map(provider => from(provider(params))))
+                return combineLatest(
+                    providers.map(provider =>
+                        from(
+                            provider(params).pipe(
+                                catchError(err => {
+                                    console.error(err)
+                                    return [null]
+                                })
+                            )
+                        )
+                    )
+                )
             })
         )
         .pipe(map(HoverMerged.from))

--- a/src/client/providers/hover.ts
+++ b/src/client/providers/hover.ts
@@ -1,5 +1,5 @@
 import { combineLatest, from, Observable } from 'rxjs'
-import { map, switchMap, catchError } from 'rxjs/operators'
+import { catchError, map, switchMap } from 'rxjs/operators'
 import { HoverMerged } from '../../client/types/hover'
 import { TextDocumentPositionParams, TextDocumentRegistrationOptions } from '../../protocol'
 import { Hover } from '../../protocol/plainTypes'


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph-extension-api/issues/105

Errors from hover providers will be logged in the console, but not emitted from `getHover`. Now, other hover providers will continue to work if one hover provider is emitting errors. However, this means that errors won't appear in the hover tooltip when they do occur.

> This PR updates the CHANGELOG.md file to describe any user-facing changes.
> This PR does not need to update the CHANGELOG because ...
